### PR TITLE
extensions: return an Iterator instead of Option<Iterator>

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ assert_eq!(lookup("folder/file.js").unwrap(), "application/javascript");
 assert_eq!(lookup("folder/.htaccess"), None);
 assert_eq!(lookup("cats"), None);
 
-assert!(extensions("application/octet-stream").unwrap().eq([
+assert!(extensions2("application/octet-stream").eq([
     "bin", "dms", "lrf", "mar", "so", "dist", "distz", "pkg", "bpk", "dump", "elc",
     "deploy", "exe", "dll", "deb", "dmg", "iso", "img", "msi", "msp", "msm", "buffer"
 ]


### PR DESCRIPTION
In #3 I changed `extensions` to return the underlying `Iterator`, instead of `collect`ing it into a `Vec`, but didn't realize at the time it didn't really make sense to return an `Option<Iterator>` (which was previously an `Option<Vec>`). Iterators already have a `size_hint` method, which makes it easy to know how many more times `next` will return a `Some`.

Since this crate is in v1, and it probably doesn't look good to release a v2 just 1 month later, I named the new method `extensions2` and left the original `extensions` fn behavior unchanged.

While I was at it I made the returned iterator into a struct implementing `Iterator`, since returning an `impl Iterator` is still a bit limiting in today's Rust and requires nightly features for things like using it as a struct's field without first `Box`ing it.