### PR TITLE
Skip lookup when empty input is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `extensions2` and `lookup` functions now early exit when an empty input is passed.
+
 ## [1.5.0] - 2021-09-11
 
 ### Changed


### PR DESCRIPTION
This PR changes the `lookup` and `extensions2` functions such that the table lookups are skipped when an empty input is passed.

I refactored the `ExtensionsIter` type to implement `Default`, producing an empty iterator.